### PR TITLE
Continuation fix

### DIFF
--- a/src/Service/LogListGetter.php
+++ b/src/Service/LogListGetter.php
@@ -114,8 +114,11 @@ class LogListGetter {
 	 * @return array
 	 */
 	private function getParamsFromOptions( $options ) {
-		$params = array( 'list' => 'logevents' );
-		$params['leprop'] = 'title|ids|type|user|timestamp|comment|details';
+		$params = array(
+			'list' => 'logevents',
+			'rawcontinue' => '',
+			'leprop' => 'title|ids|type|user|timestamp|comment|details'
+		);
 		if( $options->getType() !== '' ) {
 			$params['letype'] = $options->getType();
 		}

--- a/src/Service/LogListGetter.php
+++ b/src/Service/LogListGetter.php
@@ -54,7 +54,6 @@ class LogListGetter {
 			}
 
 			$result = $this->api->getRequest( new SimpleRequest( 'query', $params ) );
-			$limit = $limit - count( $result[ 'query' ]['logevents'] );
 
 			foreach ( $result[ 'query' ]['logevents'] as $logevent ) {
 				$logList->addLog(
@@ -77,9 +76,6 @@ class LogListGetter {
 				);
 			}
 
-			if( $limit !== null && $limit <= 0 ) {
-				return $logList;
-			}
 			if ( empty( $result['query-continue']['logevents']['lecontinue'] ) ) {
 				return $logList;
 			} else {

--- a/src/Service/PageListGetter.php
+++ b/src/Service/PageListGetter.php
@@ -71,7 +71,6 @@ class PageListGetter {
 			if( !array_key_exists( 'query', $result ) ) {
 				return $pages;
 			}
-			$limit = $limit - count( $result[ 'query' ]['categorymembers'] );
 
 			foreach ( $result['query']['categorymembers'] as $member ) {
 				$pages->addPage( new Page(
@@ -84,9 +83,6 @@ class PageListGetter {
 				);
 			}
 
-			if( $limit !== null && $limit <= 0 ) {
-				return $pages;
-			}
 			if ( empty( $result['query-continue']['categorymembers']['cmcontinue'] ) ) {
 				if ( $recursive ) {
 					//TODO implement recursive behaviour
@@ -132,7 +128,6 @@ class PageListGetter {
 			if( !array_key_exists( 'query', $result ) ) {
 				return $pages;
 			}
-			$limit = $limit - count( $result[ 'query' ]['embeddedin'] );
 
 			foreach ( $result['query']['embeddedin'] as $member ) {
 				$pages->addPage( new Page(
@@ -145,9 +140,6 @@ class PageListGetter {
 				);
 			}
 
-			if( $limit !== null && $limit <= 0 ) {
-				return $pages;
-			}
 			if ( empty( $result['query-continue']['embeddedin']['eicontinue'] ) ) {
 				return $pages;
 			} else {
@@ -181,7 +173,6 @@ class PageListGetter {
 			if( !array_key_exists( 'query', $result ) ) {
 				return $pages;
 			}
-			$limit = $limit - count( $result[ 'query' ]['pages'] );
 
 			foreach ( $result['query']['pages'] as $member ) {
 				$pages->addPage( new Page(
@@ -194,9 +185,6 @@ class PageListGetter {
 				);
 			}
 
-			if( $limit !== null && $limit <= 0 ) {
-				return $pages;
-			}
 			if ( empty( $result['query-continue']['linkshere']['glhcontinue'] ) ) {
 				return $pages;
 			} else {
@@ -236,7 +224,6 @@ class PageListGetter {
 				$params['rnlimit'] = $limit;
 			}
 			$result = $this->api->getRequest( new SimpleRequest( 'query', $params ) );
-			$limit = $limit - count( $result['query']['random'] );
 
 			foreach ( $result['query']['random'] as $member ) {
 				$pages->addPage( new Page(
@@ -249,9 +236,6 @@ class PageListGetter {
 				);
 			}
 
-			if( $limit !== null && $limit <= 0 ) {
-				return $pages;
-			}
 			if ( empty( $result['query-continue']['random']['rncontinue'] ) ) {
 				return $pages;
 			} else {

--- a/src/Service/PageListGetter.php
+++ b/src/Service/PageListGetter.php
@@ -56,6 +56,7 @@ class PageListGetter {
 			$params = array(
 				'list' => 'categorymembers',
 				'cmtitle' => $name,
+				'rawcontinue' => '',
 			);
 			if( !empty( $continue ) ) {
 				$params['cmcontinue'] = $continue;
@@ -116,7 +117,8 @@ class PageListGetter {
 			$params = array(
 				'list' => 'embeddedin',
 				'eititle' => $pageName,
-				'einamespace' => implode( '|', $options->getNamespaces() )
+				'einamespace' => implode( '|', $options->getNamespaces() ),
+				'rawcontinue' => '',
 			);
 			if( !empty( $continue ) ) {
 				$params['eicontinue'] = $continue;
@@ -168,7 +170,8 @@ class PageListGetter {
 			$params = array(
 				'prop' => 'info',
 				'generator' => 'linkshere',
-				'titles' => $pageName
+				'titles' => $pageName,
+				'rawcontinue' => '',
 			);
 			if( !empty( $continue ) ) {
 				$params['lhcontinue'] = $continue;
@@ -218,7 +221,8 @@ class PageListGetter {
 			$params = array(
 				'list' => 'random',
 				'rnlimit' => $options->getLimit(),
-				'rnnamespace' => implode( '|', $options->getNamespaces() )
+				'rnnamespace' => implode( '|', $options->getNamespaces() ),
+				'rawcontinue' => '',
 			);
 			if( $options->getRedirectsOnly() === true ) {
 				$params['rnredirect'] = 1;


### PR DESCRIPTION
There is an [API breaking change](https://lists.wikimedia.org/pipermail/wikitech-l/2015-April/081559.html) regarding the continuation feature of queries. The post suggests at least passing the parameter `rawcontinue` to still be able to use the continuation feature without switching to the newly introduced request parameters.

How `$limit` is being used in the service classes is also breaking the continuation. While it's great to be able to set the maximum number of results and also the hard limit defined by the API, it shouldn't be mixed, I guess.

* `$options->setLimit( 1000000 );` results in API warning regarding the hard limit of 500/5000 or the like
* `$options->setLimit( 500 );` results in breaking the continuation if the expected result contains more than 500 elements
* not setting a limit results in breaking the continuation if the expected result contains more than 5000 elements or an API warning regarding the limit if the user doesn't have the bot flag