### PR TITLE
Provide custom URL for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 vendor
 composer.lock
 test.php
+phpunit.xml
+nbproject

--- a/tests/integration/TestEnvironment.php
+++ b/tests/integration/TestEnvironment.php
@@ -14,12 +14,32 @@ class TestEnvironment {
 		return new self();
 	}
 
+	/** @var Mediawiki\Api\MediawikiFactory */
 	private $factory;
 
+	/**
+	 * Set up the test environment by creating a new API object pointing to a
+	 * MediaWiki installation on localhost (or elsewhere as specified by the
+	 * MEDIAWIKI_API_URL environment variable).
+	 *
+	 * @throws \Exception If the MEDIAWIKI_API_URL environment variable is set but does not end in 'api.php'
+	 */
 	public function __construct() {
-		$this->factory = new MediawikiFactory( new MediawikiApi( 'http://localhost/w/api.php' ) );
+		$apiUrl = getenv('MEDIAWIKI_API_URL');
+		if (empty($apiUrl)) {
+			$apiUrl = 'http://localhost/w/api.php';
+		} elseif (substr($apiUrl, -7) !== 'api.php') {
+			$msg = "URL incorrect: $apiUrl (the MEDIAWIKI_API_URL environment variable should end in 'api.php')";
+			throw new \Exception($msg);
+		}
+		$this->factory = new MediawikiFactory( new MediawikiApi( $apiUrl ) );
 	}
 
+	/**
+	 * Get the MediaWiki factory.
+	 *
+	 * @return \Mediawiki\Api\MediawikiFactory The factory instance.
+	 */
 	public function getFactory() {
 		return $this->factory;
 	}


### PR DESCRIPTION
This change makes it possible to specify a new environment variable,
`MEDIAWIKI_API_URL`, that will be used as the endpoint for the
integration tests. This can then be set in a local `phpunit.xml` file,
for situations in which a local development installation of MediaWiki
is installed somewhere other than at `http://localhost/w/`

Also, some phpdocs have been aded to the TestEnvironment class,
and some extra files to be ignored by Git.

The environment variable can be set in phpunit.xml with:

```xml
<php>
	<env name="MEDIAWIKI_API_URL" value="http://localhost/path/to/mediawiki/api.php" />
</php>
```