### PR TITLE
Continue all PageListGetter operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,7 @@ $services->newPageDeleter()->delete(
 	$services->newPageGetter()->getFromTitle( 'DeleteMe!' ),
 	array( 'reason' => 'Reason for Deletion' )
 );
+
+// List all pages in a category
+$pages = $services->newPageListGetter()->getPageListFromCategoryName( 'Category:Cat name' );
 ```

--- a/src/Service/PageListGetter.php
+++ b/src/Service/PageListGetter.php
@@ -30,9 +30,12 @@ class PageListGetter {
 	}
 
 	/**
-	 * @since 0.3
+	 * Get the set of pages in a given category. Extra parameters can include:
+	 *     cmtype: default 'page|subcat|file'
+	 *     cmlimit: default 10, maximum 500 (5000 for bots)
 	 *
-	 * @todo deal with continuing somehow?
+	 * @link https://www.mediawiki.org/wiki/API:Categorymembers
+	 * @since 0.3
 	 *
 	 * @param string $name
 	 * @param array $extraParams
@@ -40,40 +43,18 @@ class PageListGetter {
 	 * @returns Pages
 	 */
 	public function getPageListFromCategoryName( $name, array $extraParams = array() ) {
-		//TODO implement recursive behaviour
-
-		$pages = new Pages();
-
-		$params = array(
+		$params = array_merge($extraParams, array(
 			'list' => 'categorymembers',
 			'cmtitle' => $name,
-		);
-
-		$result =
-			$this->api->getRequest(
-				new SimpleRequest( 'query', array_merge( $extraParams, $params ) )
-			);
-		if ( !array_key_exists( 'query', $result ) ) {
-			return $pages;
-		}
-
-		foreach ( $result['query']['categorymembers'] as $member ) {
-			$pages->addPage(
-				new Page(
-					new PageIdentifier(
-						new Title( $member['title'], $member['ns'] ),
-						$member['pageid']
-					),
-					new Revisions()
-				)
-			);
-		}
-
-		return $pages;
+		));
+		return $this->runQuery($params, 'cmcontinue', 'categorymembers');
 	}
 
 	/**
-	 * @todo deal with continuing somehow?
+	 * List pages that transclude a certain page.
+	 *
+	 * @link https://www.mediawiki.org/wiki/API:Embeddedin
+	 * @since 0.5
 	 *
 	 * @param string $pageName
 	 * @param array $extraParams
@@ -81,113 +62,82 @@ class PageListGetter {
 	 * @return Pages
 	 */
 	public function getPageListFromPageTransclusions( $pageName, array $extraParams = array() ) {
-		$params = array(
+		$params = array_merge($extraParams, array(
 			'list' => 'embeddedin',
 			'eititle' => $pageName,
-		);
-
-		$result =
-			$this->api->getRequest(
-				new SimpleRequest( 'query', array_merge( $extraParams, $params ) )
-			);
-
-		$pages = new Pages();
-
-		if ( !array_key_exists( 'query', $result ) ) {
-			return $pages;
-		}
-
-		foreach ( $result['query']['embeddedin'] as $member ) {
-			$pages->addPage(
-				new Page(
-					new PageIdentifier(
-						new Title( $member['title'], $member['ns'] ),
-						$member['pageid']
-					),
-					new Revisions()
-				)
-			);
-		}
-
-		return $pages;
+		));
+		return $this->runQuery($params, 'eicontinue', 'embeddedin');
 	}
 
 	/**
-	 * @since 0.5
+	 * Get all pages that link to the given page.
 	 *
-	 * @param string $pageName
+	 * @link https://www.mediawiki.org/wiki/API:Linkshere
+	 * @since 0.5
+	 * @uses PageListGetter::runQuery()
+	 *
+	 * @param string $pageName The page name
 	 *
 	 * @returns Pages
 	 */
 	public function getFromWhatLinksHere( $pageName ) {
-		$continue = array();
-		$limit = 500;
-		$pages = new Pages();
-
-		while ( true ) {
-			$params = array(
-				'prop' => 'info',
-				'generator' => 'linkshere',
-				'titles' => $pageName,
-			);
-			if ( !empty( $continue ) ) {
-				$params = array_merge( $params, $continue );
-			}
-			$params['glhlimit'] = $limit;
-			$result = $this->api->getRequest( new SimpleRequest( 'query', $params ) );
-			if ( !array_key_exists( 'query', $result ) ) {
-				return $pages;
-			}
-
-			foreach ( $result['query']['pages'] as $member ) {
-				$pages->addPage(
-					new Page(
-						new PageIdentifier(
-							new Title( $member['title'], $member['ns'] ),
-							$member['pageid']
-						),
-						new Revisions()
-					)
-				);
-			}
-
-			if ( empty( $result['continue'] ) ) {
-				return $pages;
-			} else {
-				$continue = $result['continue'];
-			}
-		}
+		$params = array(
+			'prop' => 'info',
+			'generator' => 'linkshere',
+			'titles' => $pageName,
+		);
+		return $this->runQuery($params, 'lhcontinue', 'pages');
 	}
 
 	/**
-	 * @param array $extraParams
+	 * Get up to 10 random pages.
 	 *
-	 * @todo deal with continuing
+	 * @link https://www.mediawiki.org/wiki/API:Random
+	 * @uses PageListGetter::runQuery()
+	 *
+	 * @param array $extraParams
 	 *
 	 * @return Pages
 	 */
 	public function getRandom( array $extraParams = array() ) {
-		$params = array(
-			'list' => 'random',
-		);
-		$result =
-			$this->api->getRequest(
-				new SimpleRequest( 'query', array_merge( $extraParams, $params ) )
-			);
-
-		$pages = new Pages();
-
-		foreach ( $result['query']['random'] as $member ) {
-			$pages->addPage(
-				new Page(
-					new PageIdentifier(
-						new Title( $member['title'], $member['ns'] ),
-						$member['pageid']
-					),
-					new Revisions()
-				)
-			);
-		}
+		$params = array_merge($extraParams, array('list' => 'random'));
+		return $this->runQuery($params, null, 'random', 'id', false);
 	}
 
+	/**
+	 * Run a query to completion.
+	 *
+	 * @param string[] $params Query parameters
+	 * @param string $continueName Result subelement name for continue details
+	 * @param string $resultName Result element name for main results array
+	 * @param string $pageIdName Result element name for page ID
+	 * @param boolean $continue Whether to continue the query, using multiple requests
+	 * @return Pages
+	 */
+	protected function runQuery($params, $continueName, $resultName, $pageIdName = 'pageid', $continue = true) {
+		$pages = new Pages();
+
+		do {
+			// Set up continue parameter if it's been set already.
+			if (isset($result['continue'][$continueName])) {
+				$params[$continueName] = $result['continue'][$continueName];
+			}
+
+			// Run the actual query.
+			$result = $this->api->getRequest(new SimpleRequest('query', $params));
+			if (!array_key_exists('query', $result)) {
+				return $pages;
+			}
+
+			// Add the results to the output page list.
+			foreach ($result['query'][$resultName] as $member) {
+				$pageTitle = new Title($member['title'], $member['ns']);
+				$page = new Page(new PageIdentifier($pageTitle, $member[$pageIdName]));
+				$pages->addPage($page);
+			}
+
+		} while ($continue && isset($result['continue']));
+
+		return $pages;
+	}
 }

--- a/tests/integration/PageListGetterTest.php
+++ b/tests/integration/PageListGetterTest.php
@@ -49,10 +49,7 @@ class PageListGetterTest extends PHPUnit_Framework_TestCase {
 		$this->pageListGetter = $factory->newPageListGetter();
 	}
 
-	/**
-	 * @test
-	 */
-	public function getPageListFromCategoryName() {
+	public function testGetPageListFromCategoryName() {
 		// The empty category.
 		$emptyCategory = $this->pageListGetter->getPageListFromCategoryName($this->emptyCatName);
 		$this->assertCount(0, $emptyCategory->toArray());
@@ -62,18 +59,12 @@ class PageListGetterTest extends PHPUnit_Framework_TestCase {
 		$this->assertCount(15, $testCategory->toArray());
 	}
 
-	/**
-	 * @test
-	 */
-	public function getPageListFromPageTransclusions() {
+	public function testGetPageListFromPageTransclusions() {
 		$linksHere = $this->pageListGetter->getPageListFromPageTransclusions('Template:Test');
 		$this->assertCount(8, $linksHere->toArray());
 	}
 
-	/**
-	 * @test
-	 */
-	public function getFromWhatLinksHere() {
+	public function testGetFromWhatLinksHere() {
 		// Every even-numbered test page links to Main Page.
 		$mainPageLinks = $this->pageListGetter->getFromWhatLinksHere('Main Page');
 		$this->assertCount(7, $mainPageLinks->toArray());
@@ -84,10 +75,7 @@ class PageListGetterTest extends PHPUnit_Framework_TestCase {
 		
 	}
 
-	/**
-	 * @test
-	 */
-	public function getRandom() {
+	public function testGetRandom() {
 		// Default is 1.
 		$randomPages1 = $this->pageListGetter->getRandom();
 		$this->assertCount(1, $randomPages1->toArray());

--- a/tests/integration/PageListGetterTest.php
+++ b/tests/integration/PageListGetterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Mediawiki\Api\Test;
+
+use Mediawiki\DataModel\Content;
+use Mediawiki\DataModel\PageIdentifier;
+use Mediawiki\DataModel\Revision;
+use Mediawiki\DataModel\Title;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Test the \Mediawiki\Api\Service\PageListGetter class.
+ */
+class PageListGetterTest extends PHPUnit_Framework_TestCase {
+
+	/** @var string */
+	private $emptyCatName = 'Category:Empty category';
+
+	/** @var string */
+	private $nonemptyCatName = 'Category:Test category';
+
+	/** @var \Mediawiki\Api\Service\PageListGetter */
+	private $pageListGetter;
+
+	/**
+	 * Set up some test categories and pages.
+	 */
+	public function setUp() {
+		$factory = TestEnvironment::newDefault()->getFactory();
+
+		// An empty category.
+		$emptyCat = new PageIdentifier(new Title($this->emptyCatName));
+		$factory->newRevisionSaver()->save(new Revision(new Content(''), $emptyCat));
+
+		// A non-empty category.
+		$testCat = new PageIdentifier(new Title($this->nonemptyCatName));
+		$factory->newRevisionSaver()->save(new Revision(new Content(''), $testCat));
+
+		// Some pages in the latter.
+		// (Count must exceed the default categorymember result set size of 10.)
+		for ($i = 1; $i <= 15; $i++) {
+			$testCat = new PageIdentifier(new Title("Test page $i"));
+			// Even pages link to Main Page, odd pages transclude {{test}}.
+			$mainPageLink = (($i % 2) == 0) ? 'Go to [[Main Page]].' : 'This is a {{test}}.';
+			$content = new Content("$mainPageLink\n\n[[$this->nonemptyCatName]]");
+			$factory->newRevisionSaver()->save(new Revision($content, $testCat));
+		}
+
+		$this->pageListGetter = $factory->newPageListGetter();
+	}
+
+	/**
+	 * @test
+	 */
+	public function getPageListFromCategoryName() {
+		// The empty category.
+		$emptyCategory = $this->pageListGetter->getPageListFromCategoryName($this->emptyCatName);
+		$this->assertCount(0, $emptyCategory->toArray());
+
+		// The nonempty category.
+		$testCategory = $this->pageListGetter->getPageListFromCategoryName($this->nonemptyCatName);
+		$this->assertCount(15, $testCategory->toArray());
+	}
+
+	/**
+	 * @test
+	 */
+	public function getPageListFromPageTransclusions() {
+		$linksHere = $this->pageListGetter->getPageListFromPageTransclusions('Template:Test');
+		$this->assertCount(8, $linksHere->toArray());
+	}
+
+	/**
+	 * @test
+	 */
+	public function getFromWhatLinksHere() {
+		// Every even-numbered test page links to Main Page.
+		$mainPageLinks = $this->pageListGetter->getFromWhatLinksHere('Main Page');
+		$this->assertCount(7, $mainPageLinks->toArray());
+
+		// Nothing links to 'Test page 4'.
+		$testPageLinks = $this->pageListGetter->getFromWhatLinksHere('Test page 4');
+		$this->assertCount(0, $testPageLinks->toArray());
+		
+	}
+
+	/**
+	 * @test
+	 */
+	public function getRandom() {
+		// Default is 1.
+		$randomPages1 = $this->pageListGetter->getRandom();
+		$this->assertCount(1, $randomPages1->toArray());
+
+		// 8 random pages.
+		$randomPages2 = $this->pageListGetter->getRandom(array('rnlimit' => 8));
+		$this->assertCount(8, $randomPages2->toArray());
+	}
+
+}


### PR DESCRIPTION
This change makes all methods of the PageListGetter class
continue their queries (where the first request doesn't
retrieve the whole result set). It also adds tests for this
class, and refactors it to move the actual request-loop
code into a new protected method.

In addition, a bug [1] in the getRandom() method is fixed.

[1] https://phabricator.wikimedia.org/T142459