### PR TITLE
editInfo fix while saving revision

### DIFF
--- a/src/Service/RevisionSaver.php
+++ b/src/Service/RevisionSaver.php
@@ -37,14 +37,8 @@ class RevisionSaver {
 	 * @returns bool success
 	 */
 	public function save( Revision $revision, EditInfo $editInfo = null ) {
-		if( is_null( $editInfo ) ) {
-			if( is_null( $revision->getEditInfo() )) {
-				$editInfo = new EditInfo();
-			} else {
-				$editInfo = $revision->getEditInfo();
-			}
-		}
-
+		$editInfo = $editInfo ? $editInfo : $revision->getEditInfo();
+		
 		$result =
 			$this->api->postRequest(
 				new SimpleRequest( 'edit', $this->getEditParams( $revision, $editInfo ) )

--- a/src/Service/RevisionSaver.php
+++ b/src/Service/RevisionSaver.php
@@ -12,6 +12,7 @@ use RuntimeException;
  * @access private
  *
  * @author Addshore
+ * @author DFelten (EditInfo fix)
  */
 class RevisionSaver {
 
@@ -36,6 +37,14 @@ class RevisionSaver {
 	 * @returns bool success
 	 */
 	public function save( Revision $revision, EditInfo $editInfo = null ) {
+		if( is_null( $editInfo ) ) {
+			if( is_null( $revision->getEditInfo() )) {
+				$editInfo = new EditInfo();
+			} else {
+				$editInfo = $revision->getEditInfo();
+			}
+		}
+
 		$result =
 			$this->api->postRequest(
 				new SimpleRequest( 'edit', $this->getEditParams( $revision, $editInfo ) )

--- a/src/Service/RevisionSaver.php
+++ b/src/Service/RevisionSaver.php
@@ -38,7 +38,7 @@ class RevisionSaver {
 	 */
 	public function save( Revision $revision, EditInfo $editInfo = null ) {
 		$editInfo = $editInfo ? $editInfo : $revision->getEditInfo();
-		
+
 		$result =
 			$this->api->postRequest(
 				new SimpleRequest( 'edit', $this->getEditParams( $revision, $editInfo ) )


### PR DESCRIPTION
A revision and a revisionSaver could define an editInfo. Without these
changes the editInfo of revision is ignored and overwritten by the
editInfo of the revisionSaver, even if it's null.