### PR TITLE
Update phpcs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	},
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "^0.9.2",
-		"mediawiki/mediawiki-codesniffer": "^0.7.2",
+		"mediawiki/mediawiki-codesniffer": "^13.0",
 		"phpunit/phpunit": "~4.8"
 	},
 	"autoload": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="MediaWiki">
-	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki"/>
+	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamComment" />
+	</rule>
 	<file>.</file>
 	<arg name="extensions" value="php,php5,inc"/>
 	<arg name="encoding" value="utf8"/>

--- a/src/Generator/AnonymousGenerator.php
+++ b/src/Generator/AnonymousGenerator.php
@@ -30,6 +30,9 @@ class AnonymousGenerator implements ApiGenerator {
 		$this->params = $params;
 	}
 
+	/**
+	 * @return array
+	 */
 	public function getParams() {
 		$params = $this->params;
 		$params['generator'] = $this->name;

--- a/src/Generator/FluentGenerator.php
+++ b/src/Generator/FluentGenerator.php
@@ -32,6 +32,9 @@ class FluentGenerator implements ApiGenerator {
 		return new self( $name );
 	}
 
+	/**
+	 * @return string[]
+	 */
 	public function getParams() {
 		$params = $this->params;
 		$params['generator'] = $this->name;

--- a/src/Service/CategoryTraverser.php
+++ b/src/Service/CategoryTraverser.php
@@ -6,7 +6,6 @@ use Mediawiki\Api\CategoryLoopException;
 use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Page;
-use Mediawiki\DataModel\PageIdentifier;
 use Mediawiki\DataModel\Pages;
 
 /**
@@ -43,6 +42,9 @@ class CategoryTraverser {
 	 */
 	protected $alreadyVisited;
 
+	/**
+	 * @param MediawikiApi $api The API to connect to.
+	 */
 	public function __construct( MediawikiApi $api ) {
 		$this->api = $api;
 		$this->callbacks = [];
@@ -68,7 +70,7 @@ class CategoryTraverser {
 	/**
 	 * Register a callback that will be called for each page or category visited during the
 	 * traversal.
-	 * @param integer $type One of the 'CALLBACK_' constants of this class.
+	 * @param int $type One of the 'CALLBACK_' constants of this class.
 	 * @param callable $callback A callable that takes two \Mediawiki\DataModel\Page parameters.
 	 */
 	public function addCallback( $type, $callback ) {
@@ -102,7 +104,7 @@ class CategoryTraverser {
 		// Start a list of child pages.
 		$descendants = new Pages();
 		do {
-		    $pageListGetter = new PageListGetter( $this->api );
+			$pageListGetter = new PageListGetter( $this->api );
 			$members = $pageListGetter->getPageListFromCategoryName( $rootCatName );
 			foreach ( $members->toArray() as $member ) {
 				/** @var Title */
@@ -133,9 +135,10 @@ class CategoryTraverser {
 					$this->call( self::CALLBACK_CATEGORY, [ $member, $rootCat ] );
 					$newDescendants = $this->descend( $member, $currentPath );
 					$descendants->addPages( $newDescendants );
-					$currentPath = new Pages(); // Re-set the path.
+					// Re-set the path.
+					$currentPath = new Pages();
 				} else {
-				    // If it's a page, add it to the list and carry on.
+					// If it's a page, add it to the list and carry on.
 					$descendants->addPage( $member );
 					$this->call( self::CALLBACK_PAGE, [ $member, $rootCat ] );
 				}
@@ -146,7 +149,7 @@ class CategoryTraverser {
 
 	/**
 	 * Call all the registered callbacks of a particular type.
-	 * @param integer $type The callback type; should match one of the 'CALLBACK_' constants.
+	 * @param int $type The callback type; should match one of the 'CALLBACK_' constants.
 	 * @param mixed[] $params The parameters to pass to the callback function.
 	 */
 	protected function call( $type, $params ) {

--- a/src/Service/NamespaceGetter.php
+++ b/src/Service/NamespaceGetter.php
@@ -11,10 +11,12 @@ use Mediawiki\DataModel\NamespaceInfo;
  *
  * @author gbirke
  */
-class NamespaceGetter
-{
+class NamespaceGetter {
 	private $api;
 
+	/**
+	 * @param MediawikiApi $api The API to connect to.
+	 */
 	public function __construct( MediawikiApi $api ) {
 		$this->api = $api;
 	}
@@ -65,7 +67,7 @@ class NamespaceGetter
 	 */
 	public function getNamespaces() {
 		$namespaces = [];
-		$result =  $this->getNamespaceResult()['query'];
+		$result = $this->getNamespaceResult()['query'];
 		foreach ( $result['namespaces'] as $nsInfo ) {
 			$namespaces[$nsInfo['id']] = $this->createNamespaceFromQuery(
 				$nsInfo, $result['namespacealiases']

--- a/src/Service/PageGetter.php
+++ b/src/Service/PageGetter.php
@@ -38,7 +38,7 @@ class PageGetter {
 	 * @param int $id
 	 * @param array $extraParams
 	 *
-	 * @returns Page
+	 * @return Page
 	 */
 	public function getFromRevisionId( $id, array $extraParams = [] ) {
 		$result =
@@ -58,7 +58,7 @@ class PageGetter {
 	 * @param string|Title $title
 	 * @param array $extraParams
 	 *
-	 * @returns Page
+	 * @return Page
 	 */
 	public function getFromTitle( $title, array $extraParams = [] ) {
 		if ( $title instanceof Title ) {
@@ -81,7 +81,7 @@ class PageGetter {
 	 * @param int $id
 	 * @param array $extraParams
 	 *
-	 * @returns Page
+	 * @return Page
 	 */
 	public function getFromPageId( $id, array $extraParams = [] ) {
 		$result =
@@ -102,7 +102,7 @@ class PageGetter {
 	 * @param array $extraParams
 	 *
 	 * @throws RuntimeException
-	 * @returns Page
+	 * @return Page
 	 */
 	public function getFromPageIdentifier(
 		PageIdentifier $pageIdentifier,

--- a/src/Service/PageListGetter.php
+++ b/src/Service/PageListGetter.php
@@ -7,7 +7,6 @@ use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Page;
 use Mediawiki\DataModel\PageIdentifier;
 use Mediawiki\DataModel\Pages;
-use Mediawiki\DataModel\Revisions;
 use Mediawiki\DataModel\Title;
 
 /**
@@ -101,7 +100,7 @@ class PageListGetter {
 	public function getFromPrefix( $prefix ) {
 		$params = [
 			'list' => 'allpages',
-		    'apprefix' => $prefix,
+			'apprefix' => $prefix,
 		];
 		return $this->runQuery( $params, 'apcontinue', 'allpages' );
 	}
@@ -128,7 +127,7 @@ class PageListGetter {
 	 * @param string $contName Result subelement name for continue details
 	 * @param string $resName Result element name for main results array
 	 * @param string $pageIdName Result element name for page ID
-	 * @param boolean $cont Whether to continue the query, using multiple requests
+	 * @param bool $cont Whether to continue the query, using multiple requests
 	 * @return Pages
 	 */
 	protected function runQuery( $params, $contName, $resName, $pageIdName = 'pageid', $cont = true ) {

--- a/src/Service/PagePurger.php
+++ b/src/Service/PagePurger.php
@@ -90,16 +90,12 @@ class PagePurger {
 
 		// for every purge result
 		foreach ( $responseArray['purge'] as $purgeResponse ) {
-
 			// if the purge for the page was successful
 			if ( array_key_exists( 'purged', $purgeResponse ) ) {
-
 				// we iterate all the input pages
 				foreach ( $pagesArray as $page ) {
-
 					// and if the page from the input was successfully purged
 					if ( $purgeResponse['title'] === $page->getTitle()->getText() ) {
-
 						// add it in the purgedPages object
 						$purgedPages->addPage( $page );
 

--- a/src/Service/PageWatcher.php
+++ b/src/Service/PageWatcher.php
@@ -28,7 +28,7 @@ class PageWatcher {
 	/**
 	 * @param Page $page
 	 *
-	 * @returns bool
+	 * @return bool
 	 */
 	public function watch( Page $page ) {
 		$params = [

--- a/src/Service/Parser.php
+++ b/src/Service/Parser.php
@@ -52,7 +52,7 @@ class Parser {
 
 		$promise = $this->api->getRequestAsync( new SimpleRequest( 'parse', $params ) );
 
-		return $promise->then( function( $result ) {
+		return $promise->then( function ( $result ) {
 			return $result['parse'];
 		} );
 	}

--- a/src/Service/RevisionDeleter.php
+++ b/src/Service/RevisionDeleter.php
@@ -33,7 +33,6 @@ class RevisionDeleter {
 	 * @return bool
 	 */
 	public function delete( Revision $revision ) {
-
 		$params = [
 			'type' => 'revision',
 			'hide' => 'content',
@@ -48,7 +47,6 @@ class RevisionDeleter {
 		) );
 
 		return true;
-
 	}
 
 }

--- a/src/Service/RevisionSaver.php
+++ b/src/Service/RevisionSaver.php
@@ -34,7 +34,7 @@ class RevisionSaver {
 	 * @param Revision $revision
 	 * @param EditInfo $editInfo
 	 *
-	 * @returns bool success
+	 * @return bool success
 	 */
 	public function save( Revision $revision, EditInfo $editInfo = null ) {
 		$editInfo = $editInfo ? $editInfo : $revision->getEditInfo();

--- a/src/Service/UserGetter.php
+++ b/src/Service/UserGetter.php
@@ -28,7 +28,7 @@ class UserGetter {
 	/**
 	 * @param string $username
 	 *
-	 * @returns User
+	 * @return User
 	 */
 	public function getFromUsername( $username ) {
 		$result = $this->api->getRequest(
@@ -71,7 +71,6 @@ class UserGetter {
 				''
 			);
 		}
-
 	}
 
 }

--- a/tests/integration/CategoryTraverserTest.php
+++ b/tests/integration/CategoryTraverserTest.php
@@ -10,8 +10,7 @@ use Mediawiki\DataModel\Title;
 use Mediawiki\DataModel\Revision;
 use Mediawiki\DataModel\Content;
 
-class CategoryTraverserTest extends \PHPUnit_Framework_TestCase
-{
+class CategoryTraverserTest extends \PHPUnit_Framework_TestCase {
 
 	/** @var \Mediawiki\Api\MediawikiFactory */
 	protected $factory;

--- a/tests/integration/NamespaceGetterTest.php
+++ b/tests/integration/NamespaceGetterTest.php
@@ -7,8 +7,7 @@ use Mediawiki\Api\Service\NamespaceGetter;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\NamespaceInfo;
 
-class NamespaceGetterTest extends \PHPUnit_Framework_TestCase
-{
+class NamespaceGetterTest extends \PHPUnit_Framework_TestCase {
 	public function testGetNamespaceByCanonicalNameReturnsNullIfNamespaceWasNotFound() {
 		$nsGetter = new NamespaceGetter( $this->getApi() );
 		$this->assertNull( $nsGetter->getNamespaceByCanonicalName( 'Dummy' ) );
@@ -74,7 +73,6 @@ class NamespaceGetterTest extends \PHPUnit_Framework_TestCase
 	}
 
 	private function getRequest() {
-
 		return new SimpleRequest(
 			'query', [
 			'meta' => 'siteinfo',
@@ -83,7 +81,6 @@ class NamespaceGetterTest extends \PHPUnit_Framework_TestCase
 	}
 
 	private function getNamespaceFixture() {
-
 		return json_decode( file_get_contents( __DIR__ . '/../fixtures/namespaces.json' ), true );
 	}
 }

--- a/tests/integration/TestEnvironment.php
+++ b/tests/integration/TestEnvironment.php
@@ -12,12 +12,16 @@ use Mediawiki\Api\SimpleRequest;
  */
 class TestEnvironment {
 
+	/** @var \Mediawiki\Api\MediawikiFactory */
+	private $factory;
+
+	/**
+	 * Get a new default test environment.
+	 * @return TestEnvironment
+	 */
 	public static function newDefault() {
 		return new self();
 	}
-
-	/** @var \Mediawiki\Api\MediawikiFactory */
-	private $factory;
 
 	/**
 	 * Set up the test environment by creating a new API object pointing to a
@@ -61,7 +65,7 @@ class TestEnvironment {
 	 * @return void
 	 */
 	public function runJobs() {
-		$reqestProps = [ 'meta'=>'siteinfo', 'siprop'=>'general' ];
+		$reqestProps = [ 'meta' => 'siteinfo', 'siprop' => 'general' ];
 		$siteInfoRequest = new SimpleRequest( 'query', $reqestProps );
 		$out = $this->getApi()->getRequest( $siteInfoRequest );
 		$mainPageUrl = $out['query']['general']['base'];
@@ -75,16 +79,16 @@ class TestEnvironment {
 	 * Get the number of jobs currently in the queue.
 	 * @todo This and TestEnvironment::runJobs() should probably not live here.
 	 * @param MediawikiApi $api
-	 * @return integer
+	 * @return int
 	 */
 	public function getJobQueueLength( MediawikiApi $api ) {
 		$req = new SimpleRequest( 'query', [
-				'meta'=>'siteinfo',
-				'siprop'=>'statistics',
+				'meta' => 'siteinfo',
+				'siprop' => 'statistics',
 			]
 		);
 		$out = $api->getRequest( $req );
-		return (int) $out['query']['statistics']['jobs'];
+		return (int)$out['query']['statistics']['jobs'];
 	}
 
 }

--- a/tests/unit/Service/PagePurgerTest.php
+++ b/tests/unit/Service/PagePurgerTest.php
@@ -7,7 +7,6 @@ use Mediawiki\Api\Service\PagePurger;
 use Mediawiki\DataModel\Page;
 use Mediawiki\DataModel\Pages;
 use Mediawiki\DataModel\PageIdentifier;
-use Mediawiki\DataModel\Revisions;
 use Mediawiki\DataModel\Title;
 use PHPUnit_Framework_MockObject_MockObject;
 
@@ -93,20 +92,20 @@ class PagePurgerTest extends \PHPUnit_Framework_TestCase {
 			)
 			->will( $this->returnValue(
 				[
-	    		"batchcomplete" => "",
-	    		"purge" => [
-	        	[
-	          	"ns" => 0,
-	            "title" => "Foo",
-	            "purged" => ""
-	        	],
-	        	[
-	            "ns" => 0,
-	            "title" => "Bar",
-	            "purged" => ""
-	        	]
-	    		]
-	    	]
+					"batchcomplete" => "",
+					"purge" => [
+						[
+							"ns" => 0,
+							"title" => "Foo",
+							"purged" => ""
+						],
+						[
+							"ns" => 0,
+							"title" => "Bar",
+							"purged" => ""
+						],
+				]
+			]
 			) );
 
 		$service = new PagePurger( $api );
@@ -136,25 +135,25 @@ class PagePurgerTest extends \PHPUnit_Framework_TestCase {
 			)
 			->will( $this->returnValue(
 				[
-	    		"batchcomplete" => "",
-	    		"purge" => [
-	        	[
-	          	"ns" => 0,
-	            "title" => "Foo",
-	            "purged" => ""
-	        	],
-	        	[
-	            "ns" => 0,
-	            "title" => "Bar",
-	            "purged" => ""
-	        	],
-						[
-	            "ns" => 0,
-	            "title" => "This page really does not exist",
-	            "missing" => ""
-	        	]
-	    		]
-	    	]
+				"batchcomplete" => "",
+				"purge" => [
+					[
+						"ns" => 0,
+						"title" => "Foo",
+						"purged" => ""
+					],
+					[
+						"ns" => 0,
+						"title" => "Bar",
+						"purged" => ""
+					],
+					[
+						"ns" => 0,
+						"title" => "This page really does not exist",
+						"missing" => ""
+					],
+				]
+			]
 			) );
 
 		$service = new PagePurger( $api );


### PR DESCRIPTION
This updates to the most recent phpcs rules for MediaWiki. It excludes `MediaWiki.Commenting.FunctionComment.MissingParamComment` for now because I figured this patch is big enough on its own.