### PR TITLE
Add debug log file to TestEnvironment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ test.php
 phpunit.xml
 nbproject
 docs/_build
+log
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 	"require-dev": {
 		"jakub-onderka/php-parallel-lint": "^0.9.2",
 		"mediawiki/mediawiki-codesniffer": "^13.0",
-		"phpunit/phpunit": "~4.8"
+		"phpunit/phpunit": "~4.8",
+		"monolog/monolog": "^1.23"
 	},
 	"autoload": {
 		"psr-4": {

--- a/tests/integration/TestEnvironment.php
+++ b/tests/integration/TestEnvironment.php
@@ -6,6 +6,8 @@ use Mediawiki\Api\Guzzle\ClientFactory;
 use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\MediawikiFactory;
 use Mediawiki\Api\SimpleRequest;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
 
 /**
  * @author Addshore
@@ -46,7 +48,16 @@ class TestEnvironment {
 				." (the MEDIAWIKI_API_URL environment variable should end in 'api.php')";
 			throw new \Exception( $msg );
 		}
-		return new MediawikiApi( $apiUrl );
+
+		// Log to a local file.
+		$logger = new Logger( 'mediawiki-api' );
+		$logFile = __DIR__ . '/../../log/mediawiki-api.log';
+		$logger->pushHandler( new StreamHandler( $logFile, Logger::DEBUG ) );
+
+		// Create and return the API object.
+		$api = new MediawikiApi( $apiUrl );
+		$api->setLogger( $logger );
+		return $api;
 	}
 
 	/**


### PR DESCRIPTION
This adds a Monolog log handler to the test environment's API object, with log output going to `./log/mediawiki-api.log` in the package directory.

This is only used in testing.