### PR TITLE
Add new parent Service class and make its $api protected

### DIFF
--- a/src/Service/CategoryTraverser.php
+++ b/src/Service/CategoryTraverser.php
@@ -16,15 +16,10 @@ use Mediawiki\DataModel\Pages;
  * with an 'a' or with an 'e' in the final syllable. However the noun descendant,
  * "one who is the progeny of someone", may be spelt only with an 'a'.
  */
-class CategoryTraverser {
+class CategoryTraverser extends Service {
 
 	const CALLBACK_CATEGORY = 10;
 	const CALLBACK_PAGE = 20;
-
-	/**
-	 * @var \Mediawiki\Api\MediawikiApi
-	 */
-	protected $api;
 
 	/**
 	 * @var string[]
@@ -46,7 +41,7 @@ class CategoryTraverser {
 	 * @param MediawikiApi $api The API to connect to.
 	 */
 	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
+		parent::__construct( $api );
 		$this->callbacks = [];
 	}
 

--- a/src/Service/FileUploader.php
+++ b/src/Service/FileUploader.php
@@ -3,7 +3,6 @@
 namespace Mediawiki\Api\Service;
 
 use Exception;
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\MultipartRequest;
 use Mediawiki\Api\SimpleRequest;
 
@@ -12,22 +11,10 @@ use Mediawiki\Api\SimpleRequest;
  *
  * @author Addshore
  */
-class FileUploader {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
+class FileUploader extends Service {
 
 	/** @var int */
 	protected $chunkSize;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
 
 	/**
 	 * Set the chunk size used for chunked uploading.

--- a/src/Service/ImageRotator.php
+++ b/src/Service/ImageRotator.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\Api\UsageException;
 use Mediawiki\DataModel\File;
@@ -12,19 +11,7 @@ use Mediawiki\DataModel\File;
  *
  * @author Addshore
  */
-class ImageRotator {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class ImageRotator extends Service {
 
 	/**
 	 * NOTE: This service has not been fully tested

--- a/src/Service/LogListGetter.php
+++ b/src/Service/LogListGetter.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Log;
 use Mediawiki\DataModel\LogList;
@@ -16,18 +15,7 @@ use Mediawiki\DataModel\Title;
  *
  * @author Thomas Arrow
  */
-class LogListGetter {
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class LogListGetter extends Service {
 
 	/**
 	 * @param array $extraParams

--- a/src/Service/NamespaceGetter.php
+++ b/src/Service/NamespaceGetter.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\NamespaceInfo;
 
@@ -11,15 +10,7 @@ use Mediawiki\DataModel\NamespaceInfo;
  *
  * @author gbirke
  */
-class NamespaceGetter {
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api The API to connect to.
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class NamespaceGetter extends Service {
 
 	/**
 	 * Find a namespace by its canonical name

--- a/src/Service/PageDeleter.php
+++ b/src/Service/PageDeleter.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Page;
 use Mediawiki\DataModel\PageIdentifier;
@@ -14,19 +13,7 @@ use Mediawiki\DataModel\Title;
  *
  * @author Addshore
  */
-class PageDeleter {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class PageDeleter extends Service {
 
 	/**
 	 * @since 0.2

--- a/src/Service/PageGetter.php
+++ b/src/Service/PageGetter.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Content;
 use Mediawiki\DataModel\EditInfo;
@@ -18,19 +17,7 @@ use RuntimeException;
  *
  * @author Addshore
  */
-class PageGetter {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class PageGetter extends Service {
 
 	/**
 	 * @since 0.2

--- a/src/Service/PageListGetter.php
+++ b/src/Service/PageListGetter.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Page;
 use Mediawiki\DataModel\PageIdentifier;
@@ -14,19 +13,7 @@ use Mediawiki\DataModel\Title;
  *
  * @author Addshore
  */
-class PageListGetter {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class PageListGetter extends Service {
 
 	/**
 	 * Get the set of pages in a given category. Extra parameters can include:

--- a/src/Service/PageMover.php
+++ b/src/Service/PageMover.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Page;
 use Mediawiki\DataModel\Title;
@@ -12,19 +11,7 @@ use Mediawiki\DataModel\Title;
  *
  * @author Addshore
  */
-class PageMover {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class PageMover extends Service {
 
 	/**
 	 * @since 0.2

--- a/src/Service/PageProtector.php
+++ b/src/Service/PageProtector.php
@@ -3,7 +3,6 @@
 namespace Mediawiki\Api\Service;
 
 use InvalidArgumentException;
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Page;
 
@@ -12,19 +11,7 @@ use Mediawiki\DataModel\Page;
  *
  * @author Addshore
  */
-class PageProtector {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class PageProtector extends Service {
 
 	/**
 	 * @since 0.3

--- a/src/Service/PagePurger.php
+++ b/src/Service/PagePurger.php
@@ -3,7 +3,6 @@
 namespace Mediawiki\Api\Service;
 
 use Mediawiki\Api\Generator\ApiGenerator;
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Pages;
 use Mediawiki\DataModel\Page;
@@ -14,19 +13,7 @@ use Mediawiki\DataModel\Page;
  * @author Addshore
  * @author Thomas Arrow
  */
-class PagePurger {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class PagePurger extends Service {
 
 	/**
 	 * @since 0.3

--- a/src/Service/PageRestorer.php
+++ b/src/Service/PageRestorer.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Page;
 use Mediawiki\DataModel\Title;
@@ -13,19 +12,7 @@ use OutOfBoundsException;
  *
  * @author Addshore
  */
-class PageRestorer {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class PageRestorer extends Service {
 
 	/**
 	 * @since 0.3

--- a/src/Service/PageWatcher.php
+++ b/src/Service/PageWatcher.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Page;
 
@@ -11,19 +10,7 @@ use Mediawiki\DataModel\Page;
  *
  * @author Addshore
  */
-class PageWatcher {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class PageWatcher extends Service {
 
 	/**
 	 * @param Page $page

--- a/src/Service/Parser.php
+++ b/src/Service/Parser.php
@@ -3,7 +3,6 @@
 namespace Mediawiki\Api\Service;
 
 use GuzzleHttp\Promise\PromiseInterface;
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\PageIdentifier;
 
@@ -12,19 +11,7 @@ use Mediawiki\DataModel\PageIdentifier;
  *
  * @author Addshore
  */
-class Parser {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class Parser extends Service {
 
 	/**
 	 * @param PageIdentifier $pageIdentifier

--- a/src/Service/RevisionDeleter.php
+++ b/src/Service/RevisionDeleter.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Revision;
 
@@ -11,19 +10,7 @@ use Mediawiki\DataModel\Revision;
  *
  * @author Addshore
  */
-class RevisionDeleter {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class RevisionDeleter extends Service {
 
 	/**
 	 * @since 0.5

--- a/src/Service/RevisionPatroller.php
+++ b/src/Service/RevisionPatroller.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Revision;
 
@@ -11,19 +10,7 @@ use Mediawiki\DataModel\Revision;
  *
  * @author Addshore
  */
-class RevisionPatroller {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class RevisionPatroller extends Service {
 
 	/**
 	 * @since 0.3

--- a/src/Service/RevisionRestorer.php
+++ b/src/Service/RevisionRestorer.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Revision;
 
@@ -11,19 +10,7 @@ use Mediawiki\DataModel\Revision;
  *
  * @author Addshore
  */
-class RevisionRestorer {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class RevisionRestorer extends Service {
 
 	/**
 	 * @since 0.5

--- a/src/Service/RevisionRollbacker.php
+++ b/src/Service/RevisionRollbacker.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Revision;
 use Mediawiki\DataModel\Title;
@@ -12,19 +11,7 @@ use Mediawiki\DataModel\Title;
  *
  * @author Addshore
  */
-class RevisionRollbacker {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class RevisionRollbacker extends Service {
 
 	/**
 	 * @since 0.3

--- a/src/Service/RevisionSaver.php
+++ b/src/Service/RevisionSaver.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\EditInfo;
 use Mediawiki\DataModel\Revision;
@@ -14,19 +13,7 @@ use RuntimeException;
  * @author Addshore
  * @author DFelten (EditInfo fix)
  */
-class RevisionSaver {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class RevisionSaver extends Service {
 
 	/**
 	 * @since 0.2

--- a/src/Service/RevisionUndoer.php
+++ b/src/Service/RevisionUndoer.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\Revision;
 
@@ -11,19 +10,7 @@ use Mediawiki\DataModel\Revision;
  *
  * @author Addshore
  */
-class RevisionUndoer {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class RevisionUndoer extends Service {
 
 	/**
 	 * @param Revision $revision

--- a/src/Service/Service.php
+++ b/src/Service/Service.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MediaWiki\Api\Service;
+
+use Mediawiki\Api\MediawikiApi;
+
+/**
+ * The base service functions that all services inherit.
+ * @since 0.7.2
+ */
+abstract class Service {
+
+	/** @var MediawikiApi */
+	protected $api;
+
+	/**
+	 * @param MediawikiApi $api The API to in for this service.
+	 */
+	public function __construct( MediawikiApi $api ) {
+		$this->api = $api;
+	}
+
+}

--- a/src/Service/UserBlocker.php
+++ b/src/Service/UserBlocker.php
@@ -3,7 +3,6 @@
 namespace Mediawiki\Api\Service;
 
 use InvalidArgumentException;
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\User;
 
@@ -12,19 +11,7 @@ use Mediawiki\DataModel\User;
  *
  * @author Addshore
  */
-class UserBlocker {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class UserBlocker extends Service {
 
 	/**
 	 * @since 0.3

--- a/src/Service/UserCreator.php
+++ b/src/Service/UserCreator.php
@@ -3,7 +3,6 @@
 namespace Mediawiki\Api\Service;
 
 use InvalidArgumentException;
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\Api\UsageException;
 
@@ -12,19 +11,7 @@ use Mediawiki\Api\UsageException;
  *
  * @author Addshore
  */
-class UserCreator {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class UserCreator extends Service {
 
 	/**
 	 * @param string $username

--- a/src/Service/UserGetter.php
+++ b/src/Service/UserGetter.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\User;
 
@@ -11,19 +10,7 @@ use Mediawiki\DataModel\User;
  *
  * @author Addshore
  */
-class UserGetter {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class UserGetter extends Service {
 
 	/**
 	 * @param string $username

--- a/src/Service/UserRightsChanger.php
+++ b/src/Service/UserRightsChanger.php
@@ -2,7 +2,6 @@
 
 namespace Mediawiki\Api\Service;
 
-use Mediawiki\Api\MediawikiApi;
 use Mediawiki\Api\SimpleRequest;
 use Mediawiki\DataModel\User;
 
@@ -11,19 +10,7 @@ use Mediawiki\DataModel\User;
  *
  * @author Addshore
  */
-class UserRightsChanger {
-
-	/**
-	 * @var MediawikiApi
-	 */
-	private $api;
-
-	/**
-	 * @param MediawikiApi $api
-	 */
-	public function __construct( MediawikiApi $api ) {
-		$this->api = $api;
-	}
+class UserRightsChanger extends Service {
 
 	/**
 	 * @since 0.3


### PR DESCRIPTION
This is so custom subclasses of any of the services can access
the $api object, and to reduce a bit of duplication of code.