### PR TITLE
Fixed namespace case

### DIFF
--- a/src/Service/Service.php
+++ b/src/Service/Service.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MediaWiki\Api\Service;
+namespace Mediawiki\Api\Service;
 
 use Mediawiki\Api\MediawikiApi;
 


### PR DESCRIPTION
 Fixed namespace case (MediaWiki to Mediawiki). It causes exceptions about class name case mismatch in various class loaders, i.e. in Symfony.

```
  [RuntimeException]                                                                                                     
  Case mismatch between loaded and declared class names: Mediawiki\Api\Service\Service vs MediaWiki\Api\Service\Service  

Exception trace:
 () at /var/www/supergrosz/vendor/symfony/symfony/src/Symfony/Component/Debug/DebugClassLoader.php:175
```