### PR TITLE
Add documentation for LogListGetter

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,3 +23,5 @@ Contents
    namespace_getter.rst
    file_uploader.rst
    contributing.rst
+   user_getter.rst
+   log_list_getter.rst

--- a/docs/log_list_getter.rst
+++ b/docs/log_list_getter.rst
@@ -1,0 +1,40 @@
+Log List Getter
+===============
+
+The Log List Getter allows you to get a list of logged events in a wiki.
+
+To use it, first get a new LogListGetter object from the factory:
+
+.. code-block:: php
+
+   $api = new \Mediawiki\Api\MediawikiApi( 'http://localhost/w/api.php' );
+   $services = new \Mediawiki\Api\MediawikiFactory( $api );
+   $logListGetter = $services->newLogListGetter();
+
+
+Getting all logged events
+-------------------------
+.. code-block:: php
+
+   $logList = $logListGetter->getLogList();
+
+``getLogList`` returns a ``LogList`` object; this class is part of the `addwiki/mediawiki-datamodel`_ package.
+
+.. _addwiki/mediawiki-datamodel: https://packagist.org/packages/addwiki/mediawiki-datamodel
+
+ 
+Getting events logged by a certain user
+---------------------------------------
+``getLogList`` also accepts the same arguments as the API `list=logevents`_ query. For example to get log events related to a certain title and made by a certain user:
+
+.. _list=logevents: https://www.mediawiki.org/wiki/API:Logevents
+
+* ``letitle`` List log entries related to this title.
+* ``leuser`` List log entries made by this user.
+
+.. code-block:: php
+
+   $logList = $logListGetter->getLogList([
+       'letitle' => 'Page title',
+       'leuser' => 'Username'
+   ]);


### PR DESCRIPTION
Changes made:
* Add Instructions on how to use `LogListGetter`
* Add `log_list_getter.rst `and `user_getter.rst` to the ToC in `index.rst.`