### PR TITLE
Fix PageGetter::getRevisionsFromResult

### DIFF
--- a/src/Service/PageGetter.php
+++ b/src/Service/PageGetter.php
@@ -187,6 +187,7 @@ class PageGetter extends Service {
 		$revisions = new Revisions();
 		$pageid = $array['pageid'];
 		foreach ( $array['revisions'] as $revision ) {
+            		$revision['comment'] = (isset($revision['comment'])) ? $revision['comment'] : '';
 			$revisions->addRevision(
 				new Revision(
 					$this->getContent( $array['contentmodel'], $revision['*'] ),


### PR DESCRIPTION
Bug : undefined $revision['comment'] after an oversight/suppression of the edit summary.